### PR TITLE
chore: project improvements (lifecycle, logging, tooling)

### DIFF
--- a/.github/workflows/main-mr.yml
+++ b/.github/workflows/main-mr.yml
@@ -25,4 +25,30 @@ jobs:
       run: go vet ./...
 
     - name: Test
-      run: go test -race -v ./...
+      run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
+
+    - name: Coverage summary
+      run: go tool cover -func=coverage.out
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: coverage.out
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,10 @@ jobs:
       run: go vet ./...
 
     - name: Test
-      run: go test -race -v ./...
+      run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
+
+    - name: Coverage summary
+      run: go tool cover -func=coverage.out
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -44,4 +47,3 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-    

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - errorlint
+    - misspell
+    - unconvert
+    - bodyclose
+    - revive
+
+  settings:
+    errcheck:
+      check-type-assertions: true
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: all build test test-race vet lint fmt cover clean docker tidy help
+
+BINARY := godisco
+PKG    := ./...
+CMD    := ./app/godisco
+COVER  := coverage.out
+
+all: vet test build
+
+build:
+	go build -v -o $(BINARY) $(CMD)
+
+test:
+	go test -v $(PKG)
+
+test-race:
+	go test -race -v $(PKG)
+
+vet:
+	go vet $(PKG)
+
+lint:
+	golangci-lint run $(PKG)
+
+fmt:
+	gofmt -s -w .
+
+cover:
+	go test -race -coverprofile=$(COVER) -covermode=atomic $(PKG)
+	go tool cover -func=$(COVER)
+
+tidy:
+	go mod tidy
+
+docker:
+	docker build -t godisco:dev .
+
+clean:
+	rm -f $(BINARY) $(COVER)
+
+help:
+	@echo "Targets:"
+	@echo "  build      - compile binary"
+	@echo "  test       - run tests"
+	@echo "  test-race  - run tests with race detector"
+	@echo "  vet        - run go vet"
+	@echo "  lint       - run golangci-lint (must be installed)"
+	@echo "  fmt        - format code with gofmt"
+	@echo "  cover      - run tests with coverage report"
+	@echo "  tidy       - run go mod tidy"
+	@echo "  docker     - build Docker image"
+	@echo "  clean      - remove build artifacts"

--- a/app/godisco/main.go
+++ b/app/godisco/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -47,13 +48,17 @@ func main() {
 
 	dg.UpdateListeningStatus(viper.GetString("bot_status"))
 
-	channels.StartChannelLoops(dg)
-	// Wait here until CTRL-C or other term signal is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	loopsDone := channels.StartChannelLoops(ctx, dg)
+
 	logger.Info("Bot is now running.  Press CTRL-C to exit.")
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
+
 	logger.Info("Shutting down")
+	cancel()
+	loopsDone.Wait()
 	commands.RemoveCommands(dg, logger)
 	dg.Close()
 }

--- a/app/godisco/main.go
+++ b/app/godisco/main.go
@@ -19,7 +19,13 @@ import (
 
 func main() {
 	logger, syncLogger := logging.InitLogger()
-	defer syncLogger()
+	defer func() {
+		// zap's Sync can return ENOTTY/EBADF on stderr in some environments;
+		// nothing actionable beyond logging it.
+		if err := syncLogger(); err != nil {
+			logger.Debugw("logger sync", "error", err)
+		}
+	}()
 
 	channels.SetLogger(logger)
 	database.SetLogger(logger)
@@ -46,7 +52,9 @@ func main() {
 		logger.Fatalf("Could not open Websocket connection %s", err)
 	}
 
-	dg.UpdateListeningStatus(viper.GetString("bot_status"))
+	if err := dg.UpdateListeningStatus(viper.GetString("bot_status")); err != nil {
+		logger.Warnw("update listening status", "error", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	loopsDone := channels.StartChannelLoops(ctx, dg)
@@ -60,7 +68,9 @@ func main() {
 	cancel()
 	loopsDone.Wait()
 	commands.RemoveCommands(dg, logger)
-	dg.Close()
+	if err := dg.Close(); err != nil {
+		logger.Warnw("close discord session", "error", err)
+	}
 }
 
 func initconfig() {

--- a/channels/handlers.go
+++ b/channels/handlers.go
@@ -8,13 +8,13 @@ func VCUpdate(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 	if i.BeforeUpdate == nil {
 		userJoined(s, i)
 
-	} else if i.BeforeUpdate.ChannelID != "" && i.VoiceState.ChannelID != i.BeforeUpdate.ChannelID && i.VoiceState.ChannelID != "" {
+	} else if i.BeforeUpdate.ChannelID != "" && i.ChannelID != i.BeforeUpdate.ChannelID && i.ChannelID != "" {
 		userMoved(s, i)
 
-	} else if i.VoiceState.ChannelID == i.BeforeUpdate.ChannelID {
+	} else if i.ChannelID == i.BeforeUpdate.ChannelID {
 		return
 
-	} else if i.VoiceState.ChannelID == "" {
+	} else if i.ChannelID == "" {
 		userMoved(s, i)
 	}
 

--- a/channels/loops.go
+++ b/channels/loops.go
@@ -1,23 +1,43 @@
 package channels
 
 import (
+	"context"
+	"sync"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
 
-func StartChannelLoops(s *discordgo.Session) {
+// renameInterval is the period between full secondary-channel rename sweeps.
+// Discord rate-limits channel renames to 2 per 10 minutes, so 5 minutes is
+// the safe lower bound.
+const renameInterval = 5 * time.Minute
+
+// StartChannelLoops launches background loops that maintain managed channels.
+// The returned WaitGroup is signalled when all loops have exited; cancelling
+// ctx triggers shutdown.
+func StartChannelLoops(ctx context.Context, s *discordgo.Session) *sync.WaitGroup {
 	log.Info("Starting channel loops")
-	secondaryChannelRename(s)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		secondaryChannelRenameLoop(ctx, s)
+	}()
+	return &wg
 }
 
-func secondaryChannelRename(s *discordgo.Session) {
-	// Rename secondary channels every 5 minutes (Discord API limit)
-	ticker := time.NewTicker(time.Second * 300)
-	go func() {
-		for range ticker.C {
+func secondaryChannelRenameLoop(ctx context.Context, s *discordgo.Session) {
+	ticker := time.NewTicker(renameInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Stopping secondary channel rename loop")
+			return
+		case <-ticker.C:
 			log.Info("Checking for secondary channel rename")
 			renameAllSecondaryChannels(s)
 		}
-	}()
+	}
 }

--- a/channels/nametemplate.go
+++ b/channels/nametemplate.go
@@ -159,47 +159,43 @@ func getICAO(position int) string {
 }
 
 func renameAllSecondaryChannels(s *discordgo.Session) {
-	//1. Get all channels from db
 	var channels []models.SecondaryChannel
-	query := database.DB.Find(&channels)
-	if query.Error != nil {
-		log.Errorf("Failed to get all secondary channels %v", query.Error)
+	if err := database.DB.Find(&channels).Error; err != nil {
+		log.Errorw("rename loop: list secondary channels", "error", err)
+		return
 	}
-	//2. For each channel, get name from template
-	for _, c := range channels {
 
+	for _, c := range channels {
 		parentChannel, err := s.State.Channel(c.ParentChannelID)
 		if err != nil {
-			log.Error(err)
+			log.Errorw("rename loop: fetch parent channel",
+				"parent_channel_id", c.ParentChannelID, "channel_id", c.ChannelID, "error", err)
+			continue
 		}
 
 		secondaryChannel, err := s.State.Channel(c.ChannelID)
 		if err != nil {
-			log.Error(err)
+			log.Errorw("rename loop: fetch secondary channel",
+				"channel_id", c.ChannelID, "error", err)
+			continue
 		}
 
 		channelName, err := getChannelName(s, parentChannel, secondaryChannel, c.CreatorID)
 		if err != nil {
-			log.Error(err)
-		}
-		//3. If channel name is different from current name, rename channel
-		currentChannel, err := s.State.Channel(c.ChannelID)
-		currentChannelName := currentChannel.Name
-		if err != nil {
-			log.Error(err)
+			log.Errorw("rename loop: compute channel name",
+				"channel_id", c.ChannelID, "error", err)
+			continue
 		}
 
-		if channelName != currentChannelName {
-			_, err := s.ChannelEdit(c.ChannelID, &discordgo.ChannelEdit{
-				Name: channelName,
-			})
-			if err != nil {
-				log.Error(err)
-			}
+		if channelName == secondaryChannel.Name {
+			continue
 		}
-		//4. If channel name is the same, do nothing
+
+		if _, err := s.ChannelEdit(c.ChannelID, &discordgo.ChannelEdit{Name: channelName}); err != nil {
+			log.Errorw("rename loop: rename channel",
+				"channel_id", c.ChannelID, "new_name", channelName, "error", err)
+		}
 	}
-
 }
 
 func getUsersInChannel(s *discordgo.Session, channel *discordgo.Channel) ([]string, error) {

--- a/channels/nametemplate.go
+++ b/channels/nametemplate.go
@@ -40,12 +40,12 @@ func (c ChanneltoRename) getNamefromTemplate() (string, error) {
 	vars := neededVariables(c.Template)
 	for _, v := range vars {
 		v = strings.ToLower(v)
-		switch {
-		case v == "icao":
+		switch v {
+		case "icao":
 			c.templateVars.Icao = getICAO(c.Rank)
-		case v == "number":
+		case "number":
 			c.templateVars.Number = fmt.Sprintf("%d", c.Rank)
-		case v == "gamename":
+		case "gamename":
 			// If primary channel
 			if c.PrimaryChannel != nil {
 				user, err := c.Session.User(c.Creator)
@@ -96,9 +96,9 @@ func (c ChanneltoRename) getNamefromTemplate() (string, error) {
 				}
 			}
 
-		case v == "partysize":
+		case "partysize":
 			c.templateVars.PartySize = "N/A"
-		case v == "creatorname":
+		case "creatorname":
 			User, err := c.Session.User(c.Creator)
 			if err != nil {
 				log.Error(err)

--- a/channels/nametemplate.go
+++ b/channels/nametemplate.go
@@ -79,7 +79,7 @@ func (c ChanneltoRename) getNamefromTemplate() (string, error) {
 					if errors.Is(query.Error, gorm.ErrRecordNotFound) {
 						return "", nil
 					} else {
-						return "", fmt.Errorf("error while getting channel default name: %v", query.Error)
+						return "", fmt.Errorf("error while getting channel default name: %w", query.Error)
 					}
 				}
 				c.templateVars.GameName, err = getPrimaryChannelDefaultName(c.Session, ParentChanID.ParentChannelID)

--- a/channels/voice_update.go
+++ b/channels/voice_update.go
@@ -28,8 +28,8 @@ func userJoined(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 			"channel_id", i.ChannelID, "user_id", i.UserID, "error", err)
 		return
 	}
-	if isChannelPrimary(s, i.VoiceState.ChannelID) {
-		if _, err := createSecondaryChannelandMove(s, i, channel, i.VoiceState.UserID); err != nil {
+	if isChannelPrimary(s, i.ChannelID) {
+		if _, err := createSecondaryChannelandMove(s, i, channel, i.UserID); err != nil {
 			log.Errorw("user joined: create secondary and move",
 				"primary_channel_id", channel.ID, "user_id", i.UserID, "error", err)
 		}
@@ -227,34 +227,23 @@ func getSecondaryChannelRank(s *discordgo.Session, ParentChannelID string, Chann
 
 	// Count and compare
 	count := 0
-	found := false
 	for _, channel := range secondary_channel_ids {
-		var int_channel_id int
-		var err error
+		int_channel_id := 0
 		if ChannelID != "" {
+			var err error
 			int_channel_id, err = strconv.Atoi(ChannelID)
 			if err != nil {
 				return 0, fmt.Errorf("error while converting channel ID to int: %w", err)
 			}
-		} else {
-			int_channel_id = 0
 		}
 
-		// If found current channel_id, return value+1
 		if channel == int_channel_id {
-			found = true
 			return count + 1, nil
-		} else {
-			count += 1
 		}
-
+		count += 1
 	}
 
-	if !found {
-		return count + 1, nil
-	}
-
-	return count, nil
+	return count + 1, nil
 }
 
 func getChannelName(s *discordgo.Session, parentChannel *discordgo.Channel, secondaryChannel *discordgo.Channel, CreatorID string) (string, error) {

--- a/channels/voice_update.go
+++ b/channels/voice_update.go
@@ -24,33 +24,32 @@ func SetLogger(l *zap.SugaredLogger) {
 func userJoined(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 	channel, err := s.State.Channel(i.ChannelID)
 	if err != nil {
-		log.Error(err)
+		log.Errorw("user joined: lookup channel from state",
+			"channel_id", i.ChannelID, "user_id", i.UserID, "error", err)
 		return
 	}
 	if isChannelPrimary(s, i.VoiceState.ChannelID) {
-		_, err := createSecondaryChannelandMove(s, i, channel, i.VoiceState.UserID)
-		if err != nil {
-			log.Error(err)
+		if _, err := createSecondaryChannelandMove(s, i, channel, i.VoiceState.UserID); err != nil {
+			log.Errorw("user joined: create secondary and move",
+				"primary_channel_id", channel.ID, "user_id", i.UserID, "error", err)
 		}
 	}
-
 }
 
 func createSecondaryChannelandMove(s *discordgo.Session, i *discordgo.VoiceStateUpdate, parentChannel *discordgo.Channel, UserID string) (*discordgo.Channel, error) {
 
 	channel, err := s.State.Channel(parentChannel.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("lookup parent channel %s from state: %w", parentChannel.ID, err)
 	}
 
 	createdChannel, err := createSecondaryChannel(s, i, channel)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create secondary under %s: %w", parentChannel.ID, err)
 	}
 
-	err = s.GuildMemberMove(parentChannel.GuildID, UserID, &createdChannel.ID)
-	if err != nil {
-		return nil, err
+	if err := s.GuildMemberMove(parentChannel.GuildID, UserID, &createdChannel.ID); err != nil {
+		return nil, fmt.Errorf("move user %s to %s: %w", UserID, createdChannel.ID, err)
 	}
 
 	return createdChannel, nil
@@ -60,7 +59,7 @@ func createSecondaryChannel(s *discordgo.Session, i *discordgo.VoiceStateUpdate,
 
 	channelName, err := getChannelName(s, parentChannel, nil, i.UserID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compute channel name: %w", err)
 	}
 
 	channelToCreate := &discordgo.GuildChannelCreateData{
@@ -72,14 +71,14 @@ func createSecondaryChannel(s *discordgo.Session, i *discordgo.VoiceStateUpdate,
 		PermissionOverwrites: parentChannel.PermissionOverwrites,
 	}
 
-	// Create the new channel
 	chanCreated, err := s.GuildChannelCreateComplex(parentChannel.GuildID, *channelToCreate)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("discord create channel in guild %s: %w", parentChannel.GuildID, err)
 	}
 
-	// Add channel in database.database.DB
-	database.DB.Create(&models.SecondaryChannel{Name: chanCreated.Name, ChannelID: chanCreated.ID, GuildID: chanCreated.GuildID, ParentChannelID: parentChannel.ID, CreatorID: i.UserID})
+	if err := database.DB.Create(&models.SecondaryChannel{Name: chanCreated.Name, ChannelID: chanCreated.ID, GuildID: chanCreated.GuildID, ParentChannelID: parentChannel.ID, CreatorID: i.UserID}).Error; err != nil {
+		return nil, fmt.Errorf("persist secondary channel %s: %w", chanCreated.ID, err)
+	}
 	return chanCreated, nil
 }
 
@@ -91,12 +90,13 @@ func userMoved(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 		log.Debugf("Current channel %v is a primary channel, we need to create a new channel", i.ChannelID)
 		channel, err := s.Channel(i.ChannelID)
 		if err != nil {
-			log.Error(err)
+			log.Errorw("user moved: fetch primary channel",
+				"channel_id", i.ChannelID, "user_id", i.UserID, "error", err)
 			return
 		}
-		_, err = createSecondaryChannelandMove(s, i, channel, i.UserID)
-		if err != nil {
-			log.Error(err)
+		if _, err := createSecondaryChannelandMove(s, i, channel, i.UserID); err != nil {
+			log.Errorw("user moved: create secondary and move",
+				"primary_channel_id", channel.ID, "user_id", i.UserID, "error", err)
 		}
 	}
 
@@ -105,12 +105,15 @@ func userMoved(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 		log.Debugf("Last channel %v was a secondary channel, checking if empty", i.BeforeUpdate.ChannelID)
 		if isChannelEmpty(s, i.GuildID, i.BeforeUpdate.ChannelID) {
 			log.Debugf("Secondary channel %v is empty on guild %v, deleting it", i.BeforeUpdate.ChannelID, i.GuildID)
-			_, err := s.ChannelDelete(i.BeforeUpdate.ChannelID)
-			if err != nil {
-				log.Error(err)
+			if _, err := s.ChannelDelete(i.BeforeUpdate.ChannelID); err != nil {
+				log.Errorw("user moved: delete empty secondary",
+					"channel_id", i.BeforeUpdate.ChannelID, "guild_id", i.GuildID, "error", err)
 			}
 			log.Debugf("Removing secondary channel %v record from database.DB", i.BeforeUpdate.ChannelID)
-			database.DB.Unscoped().Where("channel_id = ?", i.BeforeUpdate.ChannelID).Delete(&models.SecondaryChannel{})
+			if err := database.DB.Unscoped().Where("channel_id = ?", i.BeforeUpdate.ChannelID).Delete(&models.SecondaryChannel{}).Error; err != nil {
+				log.Errorw("user moved: delete secondary record",
+					"channel_id", i.BeforeUpdate.ChannelID, "error", err)
+			}
 		} else {
 			log.Debugf("Secondary channel %v is not empty, no actions required", i.BeforeUpdate.ChannelID)
 		}
@@ -120,23 +123,19 @@ func userMoved(s *discordgo.Session, i *discordgo.VoiceStateUpdate) {
 }
 
 func isChannelEmpty(s *discordgo.Session, GuildID string, ChannelID string) bool {
-	count := 0
 	guild, err := s.State.Guild(GuildID)
 	if err != nil {
-		log.Error(err)
-	}
-
-	for _, channel := range guild.VoiceStates {
-		if channel.ChannelID == ChannelID {
-			count += 1
-		}
-	}
-
-	if count == 0 {
-		return true
-	} else {
+		log.Errorw("isChannelEmpty: fetch guild",
+			"guild_id", GuildID, "channel_id", ChannelID, "error", err)
 		return false
 	}
+
+	for _, vs := range guild.VoiceStates {
+		if vs.ChannelID == ChannelID {
+			return false
+		}
+	}
+	return true
 }
 
 func isChannelPrimary(s *discordgo.Session, ChannelID string) bool {

--- a/channels/voice_update.go
+++ b/channels/voice_update.go
@@ -170,7 +170,7 @@ func getPrimaryChannelTemplate(s *discordgo.Session, ChannelID string) (string, 
 		if errors.Is(managed_channel.Error, gorm.ErrRecordNotFound) {
 			return "", nil
 		} else {
-			return "", fmt.Errorf("error while getting channel template: %v", managed_channel.Error)
+			return "", fmt.Errorf("error while getting channel template: %w", managed_channel.Error)
 		}
 	}
 
@@ -189,7 +189,7 @@ func getPrimaryChannelDefaultName(s *discordgo.Session, ChannelID string) (strin
 		if errors.Is(query.Error, gorm.ErrRecordNotFound) {
 			return "", nil
 		} else {
-			return "", fmt.Errorf("error while getting channel default name: %v", query.Error)
+			return "", fmt.Errorf("error while getting channel default name: %w", query.Error)
 		}
 	}
 
@@ -208,7 +208,7 @@ func getSecondaryChannelRank(s *discordgo.Session, ParentChannelID string, Chann
 		if errors.Is(secondary_channels.Error, gorm.ErrRecordNotFound) {
 			return 1, nil
 		} else {
-			return 0, fmt.Errorf("error while getting secondary channel count : %v", secondary_channels.Error)
+			return 0, fmt.Errorf("error while getting secondary channel count : %w", secondary_channels.Error)
 		}
 	}
 
@@ -217,7 +217,7 @@ func getSecondaryChannelRank(s *discordgo.Session, ParentChannelID string, Chann
 	for _, channel := range channels {
 		int_channel_id, err := strconv.Atoi(channel.ChannelID)
 		if err != nil {
-			return 0, fmt.Errorf("error while converting channel ID to int: %v", err)
+			return 0, fmt.Errorf("error while converting channel ID to int: %w", err)
 		}
 		secondary_channel_ids = append(secondary_channel_ids, int_channel_id)
 	}
@@ -234,7 +234,7 @@ func getSecondaryChannelRank(s *discordgo.Session, ParentChannelID string, Chann
 		if ChannelID != "" {
 			int_channel_id, err = strconv.Atoi(ChannelID)
 			if err != nil {
-				return 0, fmt.Errorf("error while converting channel ID to int: %v", err)
+				return 0, fmt.Errorf("error while converting channel ID to int: %w", err)
 			}
 		} else {
 			int_channel_id = 0
@@ -294,7 +294,7 @@ func getChannelName(s *discordgo.Session, parentChannel *discordgo.Channel, seco
 			Rank:             channelrank,
 		}
 	} else {
-		return "nil", fmt.Errorf("error while getting channel type: %v", err)
+		return "nil", fmt.Errorf("error while getting channel type: %w", err)
 	}
 
 	var channelName string

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -46,8 +46,13 @@ var (
 	}
 )
 
-func RegisterCommands(dg *discordgo.Session, log *zap.SugaredLogger) error {
-	if err := addCommands(dg, log); err != nil {
+// log is the package-level logger used by command handlers. It is set by
+// RegisterCommands and must not be used before then.
+var log *zap.SugaredLogger
+
+func RegisterCommands(dg *discordgo.Session, l *zap.SugaredLogger) error {
+	log = l
+	if err := addCommands(dg, l); err != nil {
 		return err
 	}
 	addHandlers(dg)

--- a/commands/handlers.go
+++ b/commands/handlers.go
@@ -13,33 +13,17 @@ func Ping(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	delay := time.Since(messageTime)
 	heartbeat := s.HeartbeatLatency()
 	content := fmt.Sprintf("Pong! delay : %v, hearbeat : %vms", delay.Round(time.Millisecond), heartbeat)
-
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: content,
-		},
-	})
+	respond(s, i, content)
 }
 
 func Help(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: "Help isn't available yet, yeah I know, that sucks...",
-		},
-	})
+	respond(s, i, "Help isn't available yet, yeah I know, that sucks...")
 }
 
 func CreatePrimary(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	userPerm := i.Member.Permissions
 	if userPerm&discordgo.PermissionManageChannels == 0 {
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: "You don't have permission to do that.",
-			},
-		})
+		respond(s, i, "You don't have permission to do that.")
 		return
 	}
 
@@ -63,12 +47,24 @@ func CreatePrimary(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		}
 	}
 
-	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	respond(s, i, content)
+}
+
+// respond sends a chat-message response to the interaction and logs any
+// error from the Discord API rather than letting it fall on the floor.
+func respond(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: content,
 		},
 	})
+	if err != nil && log != nil {
+		log.Errorw("interaction respond",
+			"interaction_id", i.ID,
+			"command", i.ApplicationCommandData().Name,
+			"error", err)
+	}
 }
 
 // optionString safely extracts a string option by name from a slash command's

--- a/commands/handlers.go
+++ b/commands/handlers.go
@@ -37,11 +37,11 @@ func CreatePrimary(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		content = "Missing or invalid options."
 	default:
 		if err := channels.TestTemplate(s, defaultName); err != nil {
-			content = "An error occured while testing the template"
+			content = "An error occurred while testing the template"
 		} else if err := channels.TestTemplate(s, template); err != nil {
-			content = "An error occured while testing the template"
+			content = "An error occurred while testing the template"
 		} else if _, err := channels.CreatePrimaryChannel(s, i.GuildID, template, defaultName); err != nil {
-			content = "An error occured while creating the channel"
+			content = "An error occurred while creating the channel"
 		} else {
 			content = fmt.Sprintf("Created primary with Default Name : '%s' and the template : '%s' \nYou can now change the name/settings/position... of the channel without any issue !", defaultName, template)
 		}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,15 +1,34 @@
 package logging
 
-import "go.uber.org/zap"
+import (
+	"os"
+	"strings"
 
-// InitLogger creates a new development sugared logger and returns it
-// alongside a sync function. The caller is responsible for deferring
-// the sync function so buffered log entries are flushed at shutdown.
+	"go.uber.org/zap"
+)
+
+// InitLogger creates a new sugared logger and returns it alongside a sync
+// function. The caller is responsible for deferring the sync function so
+// buffered log entries are flushed at shutdown.
+//
+// The logger is built using zap's production config by default, which emits
+// JSON-formatted logs suitable for log aggregators. Setting GODISCO_LOG_MODE
+// to "development" (or "dev") switches to the human-readable development
+// config with stacktraces.
 func InitLogger() (*zap.SugaredLogger, func() error) {
-	logger, err := zap.NewDevelopment()
+	logger, err := buildLogger(os.Getenv("GODISCO_LOG_MODE"))
 	if err != nil {
 		panic(err)
 	}
 	sugar := logger.Sugar()
 	return sugar, logger.Sync
+}
+
+func buildLogger(mode string) (*zap.Logger, error) {
+	switch strings.ToLower(mode) {
+	case "development", "dev":
+		return zap.NewDevelopment()
+	default:
+		return zap.NewProduction()
+	}
 }


### PR DESCRIPTION
## Summary

A handful of low-risk improvements that came out of an audit of the codebase.

### Runtime fixes
- **Goroutine lifecycle.** `channels.StartChannelLoops` now takes a `context.Context` and returns a `*sync.WaitGroup`. The rename loop selects on `ctx.Done()` and stops its ticker on shutdown. `main.go` cancels the context on SIGINT/SIGTERM and waits for the loop before closing the Discord session — previously the goroutine leaked and the bot couldn't shut down cleanly.
- **Production logger.** `logging.InitLogger` defaults to `zap.NewProduction()` (JSON, no stacktraces by default). `GODISCO_LOG_MODE=development` opts back into the dev logger. The previous code shipped the dev logger in production.
- **Error wrapping.** `channels/voice_update.go` and the rename loop now wrap errors with `%w` and log structured fields (`channel_id`, `user_id`, `guild_id`, ...). Several silent DB-error paths were replaced with explicit error checks.
- **`isChannelEmpty` safety.** On guild-fetch error the function now returns `false` instead of `true`. Previously a transient state error would cause a managed channel to be deleted because the code mistook the error for "no users present".

### Tooling
- **`.golangci.yml`** (v2 schema): errcheck, errorlint, staticcheck, ineffassign, unused, govet, revive, bodyclose, misspell, unconvert + gofmt/goimports formatters.
- **`Makefile`** with `build`, `test`, `test-race`, `vet`, `lint`, `fmt`, `cover`, `tidy`, `docker`, `clean`, `help`.
- **CI**: PR workflow now runs tests with `-coverprofile`, prints a coverage summary, uploads `coverage.out` as an artifact, and adds a separate `lint` job using `golangci/golangci-lint-action@v8`. Push-to-main workflow gets the same coverage step.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./...` (all packages green)
- [x] `gofmt -l .` (clean)
- [ ] CI: confirm new lint job and coverage step pass on this PR
- [ ] Manual: verify clean shutdown on SIGINT (no leaked goroutine, loop logs `Stopping secondary channel rename loop`)
- [ ] Manual: verify production JSON logs by default; `GODISCO_LOG_MODE=development` switches to dev format

https://claude.ai/code/session_01QaCbCfRUbRQTWYmTTbPur8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaCbCfRUbRQTWYmTTbPur8)_